### PR TITLE
Update class name for tailwindCss 2.0.2

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ module.exports = ({ addComponents }) => {
         '@apply font-semibold text-gray-800': {},
       },
       '> p code, > ul li *:not(pre) code, > ul li > code, > ol li *:not(pre) code, > ol li > code, p& code&': {
-        '@apply inline-block bg-gray-100 rounded-sm text-sm px-1 leading-none whitespace-no-wrap text-purple-600 font-mono align-baseline font-normal': {},
+        '@apply inline-block bg-gray-100 rounded-sm text-sm px-1 leading-none whitespace-nowrap text-purple-600 font-mono align-baseline font-normal': {},
       },
       '> p strong code, > ul li strong code, > ol li strong code': {
         '@apply font-normal': {},


### PR DESCRIPTION
fix class name of `whitespace-nowrap` from v1 to v2 tailwind